### PR TITLE
additional changes for lower memory usage

### DIFF
--- a/examples/dreambooth/launch.sh
+++ b/examples/dreambooth/launch.sh
@@ -11,11 +11,15 @@ accelerate launch train_dreambooth.py \
   --with_prior_preservation \
   --instance_prompt="photo of sks guy" \
   --class_prompt="photo of a guy" \
-  --resolution=512 \
+  --resolution=256 \
   --train_batch_size=1 \
-  --gradient_accumulation_steps=1 \
+  --sample_batch_size 1 \
+  --gradient_accumulation_steps=4 \
   --learning_rate=5e-6 \
   --lr_scheduler="constant" \
   --lr_warmup_steps=0 \
   --num_class_images=200 \
-  --max_train_steps=800
+  --max_train_steps=800 \
+  --use_8bit_adam \
+  --gradient_checkpointing \
+  --mixed_precision bf16


### PR DESCRIPTION
lower batch size with higher gradient accumulation uses less memory for same training benefit; use_8bit_adam greatly reduces memory for adam; gradient_checkpointing greatly reduces memory; mixed_precision bf16 is faster for same memory usage.

Note that I can't test these locally yet (on windows) so not positive they are all of benefit.  Will probably test tomorrow on colab.