### PR TITLE
Argument to add training info json

### DIFF
--- a/examples/dreambooth/launch.sh
+++ b/examples/dreambooth/launch.sh
@@ -22,5 +22,5 @@ accelerate launch train_dreambooth.py \
   --lr_warmup_steps=0 \
   --num_class_images=50 \
   --sample_batch_size=4 \
-  --max_train_steps=10 \
+  --max_train_steps=1000 \
   --save_training_info

--- a/examples/dreambooth/launch.sh
+++ b/examples/dreambooth/launch.sh
@@ -22,4 +22,5 @@ accelerate launch train_dreambooth.py \
   --lr_warmup_steps=0 \
   --num_class_images=50 \
   --sample_batch_size=4 \
-  --max_train_steps=1000
+  --max_train_steps=10 \
+  --save_training_info

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -188,6 +188,14 @@ def parse_args():
     )
     parser.add_argument("--not_cache_latents", action="store_true", help="Do not precompute and cache latents from VAE.")
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
+    parser.add_argument(
+        "--save_training_info",
+         action="store_true", 
+         help=(
+            "Saves dreambooth_info.json into the output directory with"
+            " info about how the model was trained"
+        ),
+    )
 
     args = parser.parse_args()
     env_local_rank = int(os.environ.get("LOCAL_RANK", -1))
@@ -348,7 +356,7 @@ def main():
         log_with="tensorboard",
         logging_dir=logging_dir,
     )
-
+    
     if args.seed is not None:
         set_seed(args.seed)
 
@@ -457,6 +465,14 @@ def main():
         size=args.resolution,
         center_crop=args.center_crop,
     )
+
+    if args.save_training_info:
+        import json
+        with open(os.path.join(args.output_dir, "dreambooth_info.json"), 'w') as f:
+            model_info = vars(args)
+            model_info["num_instance_images"] = vars(train_dataset).get("num_instance_images", "")
+            model_info["num_class_images"] = vars(train_dataset).get("num_class_images", "")
+            json.dump(model_info, f, indent=2)
 
     def collate_fn(examples):
         input_ids = [example["instance_prompt_ids"] for example in examples]


### PR DESCRIPTION
Adds a new argument --save_training_data that will create a dreambooth_info.json file in the output directory with arguments passed to train_dreambooth.py. Along with number of class images and instance images.