### PR TITLE
pretrained_vae_name_or_path is not required

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -40,7 +40,6 @@ def parse_args():
         "--pretrained_vae_name_or_path",
         type=str,
         default=None,
-        required=True,
         help="Path to pretrained vae or vae identifier from huggingface.co/models.",
     )
     parser.add_argument(


### PR DESCRIPTION
The pretrained_vae_name_or_path is an optional flag that marked as required.