### PR TITLE
Set subfolder for vae if --pretrained_vae_name_or_path is not specified

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -629,7 +629,7 @@ def main():
                 args.pretrained_model_name_or_path,
                 unet=accelerator.unwrap_model(unet),
                 text_encoder=text_enc_model,
-                vae=AutoencoderKL.from_pretrained(args.pretrained_vae_name_or_path or args.pretrained_model_name_or_path, use_auth_token=True),
+                vae=AutoencoderKL.from_pretrained(args.pretrained_vae_name_or_path or args.pretrained_model_name_or_path, subfolder=None if args.pretrained_vae_name_or_path else "vae", use_auth_token=True),
                 safety_checker=None,
                 scheduler=scheduler,
                 torch_dtype=torch.float16,


### PR DESCRIPTION
This PR aims to resolve this error

```txt
Traceback (most recent call last):
  File "train_dreambooth.py", line 750, in <module>
    main()
  File "train_dreambooth.py", line 744, in main
    save_weights(global_step)
  File "train_dreambooth.py", line 632, in save_weights
    vae=AutoencoderKL.from_pretrained(args.pretrained_vae_name_or_path or args.pretrained_model_name_or_path,),
  File "/usr/local/lib/python3.7/dist-packages/diffusers/modeling_utils.py", line 356, in from_pretrained
    f"{pretrained_model_name_or_path} does not appear to have a file named {WEIGHTS_NAME}."
OSError: xxxxxx/yyyyyyy does not appear to have a file named diffusion_pytorch_model.bin.
```