### PR TITLE
Added xformer wheels (Google Colab, Python 3.8)

### DIFF
--- a/examples/dreambooth/DreamBooth_Stable_Diffusion.ipynb
+++ b/examples/dreambooth/DreamBooth_Stable_Diffusion.ipynb
@@ -106,7 +106,8 @@
     }
    ],
    "source": [
-    "%pip install -q https://github.com/metrolobo/xformers_wheels/releases/download/1d31a3ac_various_6/xformers-0.0.14.dev0-cp37-cp37m-linux_x86_64.whl\n",
+    "%pip install -q !pip install -q https://github.com/OMGhozlan/xformers_colab/releases/download/1.0.0/xformers-0.0.15.dev0+cu11.2-cp38-cp38-linux_x86_64.whl\n",
+    "# %pip install -q https://github.com/metrolobo/xformers_wheels/releases/download/1d31a3ac_various_6/xformers-0.0.14.dev0-cp37-cp37m-linux_x86_64.whl\n",
     "# These were compiled on Tesla T4, should also work on P100, thanks to https://github.com/metrolobo\n",
     "\n",
     "# If precompiled wheels don't work, install it with the following command. It will take around 40 minutes to compile.\n",


### PR DESCRIPTION
I tried to use this script today (as I normally do) and I found that the xformer wheels were not working anymore. I built it on Google Colab (Tesla T4) and add a link to it