### PR TITLE
version stablize bitsandbytes

### DIFF
--- a/examples/dreambooth/DreamBooth_Stable_Diffusion.ipynb
+++ b/examples/dreambooth/DreamBooth_Stable_Diffusion.ipynb
@@ -55,7 +55,7 @@
     "!wget -q https://github.com/ShivamShrirao/diffusers/raw/main/scripts/convert_diffusers_to_original_stable_diffusion.py\n",
     "%pip install -qq git+https://github.com/ShivamShrirao/diffusers\n",
     "%pip install -q -U --pre triton\n",
-    "%pip install -q accelerate==0.12.0 transformers ftfy bitsandbytes gradio natsort"
+    "%pip install -q accelerate==0.12.0 transformers ftfy bitsandbytes==0.35.0 gradio natsort"
    ]
   },
   {


### PR DESCRIPTION
There has been a degradation in quality for the generated models created with this colab notebook due to an upstream update in the `bitsandbytes` dependency. This issue has been reported in the Dreambooth Discord and in this repository. 

Rolling back to version `0.35.0` of the `bitsandbytes` dependency appears to resolve the issue and produce results in the expected quality.

See this release yesterday: https://github.com/TimDettmers/bitsandbytes/releases/tag/0.36.0

Thanks to Manders for discovering and testing this issue. All credit to them.