### PR TITLE
Prompt per image (like regular fine-tuning)

### DIFF
--- a/examples/dreambooth/README.md
+++ b/examples/dreambooth/README.md
@@ -121,7 +121,7 @@ export MODEL_NAME="CompVis/stable-diffusion-v1-4"
 export INSTANCE_DIR="path-to-instance-images"
 export OUTPUT_DIR="path-to-save-model"
 
-accelerate launch /train/train_dreambooth.py \
+accelerate launch train_dreambooth.py \
   --pretrained_model_name_or_path=$MODEL_NAME  \
   --instance_data_dir=$INSTANCE_DIR \
   --output_dir=$OUTPUT_DIR \

--- a/examples/dreambooth/README.md
+++ b/examples/dreambooth/README.md
@@ -112,6 +112,32 @@ accelerate launch train_dreambooth.py \
   --max_train_steps=800
 ```
 
+### Using prompt per image
+
+You can use `--read_prompts_from_txts` to make the script use a separate prompt for each image. This makes the training act like regular fine-tuning and not like Dreambooth. For each image, you need to create a txt file with the prompt. For example, if image is named `dog.png` create `dog.png.txt`.
+
+```bash
+export MODEL_NAME="CompVis/stable-diffusion-v1-4"
+export INSTANCE_DIR="path-to-instance-images"
+export OUTPUT_DIR="path-to-save-model"
+
+accelerate launch /train/train_dreambooth.py \
+  --pretrained_model_name_or_path=$MODEL_NAME  \
+  --instance_data_dir=$INSTANCE_DIR \
+  --output_dir=$OUTPUT_DIR \
+  --resolution=512 \
+  --train_batch_size=1 \
+  --train_text_encoder \
+  --mixed_precision="fp16" \
+  --use_8bit_adam \
+  --gradient_accumulation_steps=1 \
+  --gradient_checkpointing \
+  --learning_rate=1e-6 \
+  --lr_scheduler="constant" \
+  --lr_warmup_steps=0 \
+  --max_train_steps=800 \
+  --read_prompts_from_txts
+```
 
 ### Training on a 16GB GPU:
 


### PR DESCRIPTION
It seems that in order to turn Dreambooth training into regular fine-tuning, all you need to do is use a separate prompt for each image. At least, as far as I understand. :smile:

I've been experimenting with this option, and the resulting model seems to be more controllable - during inference, generated images more closely followed the prompt and also I was able to edit the prompt more freely. It felt like the model was no longer "glued" to the instance prompt and had more understanding of the prompt's parts.

Inspired by https://github.com/andreasjansson/monkey-island-sd, specifically [this change](https://github.com/andreasjansson/monkey-island-sd/blob/09f2a21e76ad402640afe49b6b731ffc5dcfb880/train_dreambooth.py#L283).